### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,20 +6,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-LCDdogmSPI KEYWORD1
+LCDdogmSPI	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-clear 		KEYWORD2
-commandWrite 	KEYWORD2
-cursorTo 	KEYWORD2
-init 		KEYWORD2
-print 		KEYWORD2
-dataWrite		KEYWORD2
-printIn 	KEYWORD2
-commandWriteNibble 	KEYWORD2
+clear	KEYWORD2
+commandWrite	KEYWORD2
+cursorTo	KEYWORD2
+init	KEYWORD2
+print	KEYWORD2
+dataWrite	KEYWORD2
+printIn	KEYWORD2
+commandWriteNibble	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords